### PR TITLE
Refactored CMake parts of the source

### DIFF
--- a/Analytical_wrapping/CMakeLists.txt
+++ b/Analytical_wrapping/CMakeLists.txt
@@ -1,33 +1,9 @@
-cmake_minimum_required(VERSION 3.2)
-project(Analytical_wrapping)
-
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-# DEFINE HERE THE LOCATION OF YOUR OPENSIM-CORE INSTALLATION!!!
-#set(CMAKE_MODULE_PATH /home/none/opensim-core/lib/cmake)
-set(OpenSim_DIR "/home/none/opensim-core/lib/cmake/OpenSim")
-find_package(OpenSim REQUIRED)
-
-
 add_executable(test_suite
         test_suite.cpp
         buildModel.cpp
         analyticalSolution.cpp)
-target_link_libraries(test_suite ${Simbody_LIBRARIES} osimTools)
+
+target_link_libraries(test_suite common_options_target)
 set_target_properties(test_suite PROPERTIES FOLDER "Examples")
 add_test(NAME    test_suite
          COMMAND test_suite noVisualizer simulateOnce)
-
-#target_link_libraries(exampleHopperDeviceAnswers ${Simbody_LIBRARIES} osimTools)
-#set_target_properties(exampleHopperDeviceAnswers PROPERTIES FOLDER "Examples")
-# The answers file uses `#pragma region` to facilitate code folding
-# when using this example in a live demonstration, but these pragmas are only
-# recognized by MSVC.
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
-        CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    target_compile_options(test_suite PUBLIC
-            -Wno-unknown-pragmas)
-endif()
-#add_test(NAME    exampleHopperDeviceAnswers
-#         COMMAND exampleHopperDeviceAnswers noVisualizer)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.2)
+project(OpenSim_RA)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+# just put the binaries into the build output dir, rather than into a
+# subfolder
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
+find_package(OpenSim REQUIRED)
+find_package(Simbody REQUIRED)
+
+# any target that links to this INTERFACE target will transitively
+# inherit all the library, include, compile, etc. options of that
+# target. It's a handy trick for configuring all the dependencies +
+# options on one target, rather than having to duplicate it
+add_library(common_options_target INTERFACE)
+target_link_libraries(common_options_target INTERFACE
+  SimTKcommon
+  SimTKmath
+  SimTKsimbody
+  osimTools)
+
+# this uses generator expressions. see (find "COMPILER_ID")
+#     https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html
+target_compile_options(common_options_target INTERFACE
+  # The answers file uses `#pragma region` to facilitate code folding
+  # when using this example in a live demonstration, but these pragmas
+  # are only recognized by MSVC.
+  "$<$<CXX_COMPILER_ID:GNU>:-Wno-unknown-pragmas>"
+  "$<$<CXX_COMPILER_ID:Clang>:-Wno-unknown-pragmas>")
+
+add_subdirectory(Analytical_wrapping)
+add_subdirectory(Wrapping_surfaces)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # subfolder
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
+# so that CLion/qtcreator can open your project without further
+# configuring
+list(APPEND CMAKE_PREFIX_PATH "/home/none/opensim-core/lib/cmake/")
+
 find_package(OpenSim REQUIRED)
 find_package(Simbody REQUIRED)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # OpenSim_RA
+
 OpenSim model repository for models that I use for my tasks as research assistent
+
+## Building (Debian/Ubuntu)
+
+```bash
+./scripts/linux_configure && ./scripts/linux_build
+```
 
 ## Wrapping_surfaces
 This is a test on different wrapping surfaces (cylinder, ellipse, sphere, toroid) on the hopper example from the source code.

--- a/Wrapping_surfaces/CMakeLists.txt
+++ b/Wrapping_surfaces/CMakeLists.txt
@@ -1,31 +1,7 @@
-cmake_minimum_required(VERSION 3.2)
-project(Wrapping_surfaces)
-
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-# DEFINE HERE THE LOCATION OF YOUR OPENSIM-CORE INSTALLATION!!!
-set(OpenSim_DIR "/home/none/opensim-core/lib/cmake/OpenSim")
-find_package(OpenSim REQUIRED)
-
-
 add_executable(exampleHopperDevice
     exampleHopperDevice.cpp
     buildHopperModel.cpp)
-target_link_libraries(exampleHopperDevice ${Simbody_LIBRARIES} osimTools)
+target_link_libraries(exampleHopperDevice common_options_target)
 set_target_properties(exampleHopperDevice PROPERTIES FOLDER "Examples")
 add_test(NAME    exampleHopperDevice
          COMMAND exampleHopperDevice noVisualizer simulateOnce)
-
-#target_link_libraries(exampleHopperDeviceAnswers ${Simbody_LIBRARIES} osimTools)
-#set_target_properties(exampleHopperDeviceAnswers PROPERTIES FOLDER "Examples")
-# The answers file uses `#pragma region` to facilitate code folding
-# when using this example in a live demonstration, but these pragmas are only
-# recognized by MSVC.
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
-        CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    target_compile_options(exampleHopperDevice PUBLIC
-            -Wno-unknown-pragmas)
-endif()
-#add_test(NAME    exampleHopperDeviceAnswers
-#         COMMAND exampleHopperDeviceAnswers noVisualizer)

--- a/scripts/linux_build
+++ b/scripts/linux_build
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+cd build/ && make -j$(nproc)

--- a/scripts/linux_configure
+++ b/scripts/linux_configure
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# make bash stricter than normal
+set -ueo pipefail
+
+# because some developers are too lazy to set this every time they checkout :-)
+possible_opensim_locs=(
+    "/home/none/opensim-core/lib/cmake/"
+    "/home/adam/Desktop/opensim-master/opensim-core-install/lib/cmake"
+)
+
+# join bash list by delimiter
+# from: https://stackoverflow.com/questions/1527049/how-can-i-join-elements-of-an-array-in-bash
+function join_by { local d=$1; shift; local f=$1; shift; printf %s "$f" "${@/#/$d}"; }
+
+prefix_dir=$(join_by ";" ${possible_opensim_locs[@]})
+
+# make bash more verbose than normal
+set -x
+
+mkdir -p build/
+cd build/
+cmake -DCMAKE_PREFIX_PATH="${prefix_dir}" ..


### PR DESCRIPTION
These are mostly minor quality-of-life changes to the CMake-level of the codebase, to make it easier to expand outwards (adding more test suites should hopefully be easier now that the duplicated parts are common) and make it cleaner for later integration.

- Moved duplicated parts of CMakeLists.txt into top-level CMakeLists.txt file

- Moved hard-coded user paths into Linux-specific script, such that the
  CMakeLists.txt file doesn't contain user-specific build info

- Used generator expressions for compiler settings

- Confirmed to build + run on Debian buster install /w OpenSim4.x